### PR TITLE
[#72] Low performance khi play animation file 12345.spr

### DIFF
--- a/SPRNetTool/ViewModel/DebugPageViewModel.cs
+++ b/SPRNetTool/ViewModel/DebugPageViewModel.cs
@@ -348,14 +348,12 @@ namespace SPRNetTool.ViewModel
                     }
                     else if (castArgs.IsPlayingAnimation == true)
                     {
-
-                        IsPlayingAnimation = true;
                         ViewModelOwner?.ViewDispatcher.Invoke(() =>
                         {
+                            IsPlayingAnimation = true;
                             CurrentlyDisplayedBitmapSource = castArgs.CurrentDisplayingSource;
                             CurrentFrameIndex = castArgs.SprFrameIndex;
-                        }, DispatcherPriority.Render);
-
+                        }, DispatcherPriority.Input);
                     }
                     break;
             }


### PR DESCRIPTION
### Hiện tượng giật, lag khi play animation là do dispatcher được chọn có priority quá cao (render), nên chọn priority là input hoặc background cho animation

### nút play/pause thi thoảng không hiển thị đúng là do dispatcher data bind nhỏ hơn dispatcher render, nên khi animation có interval nhỏ (fps cao) việc gọi cập nhật view cho element có dispatcher là data bind có thể bị miss mất