### PR TITLE
[#81] Sau khi edit frame size, thay đổi frame index gây lỗi vị trí ảnh và kích thước

### DIFF
--- a/SPRNetTool/Data/SPRData.cs
+++ b/SPRNetTool/Data/SPRData.cs
@@ -179,7 +179,7 @@ namespace SPRNetTool.Data
         public short frameOffY { get; set; }
 
         public byte[] encryptedFrameData { get; set; }
-        public PaletteColor[] decodedFrameData { get; set; }
+        public PaletteColor[] originDecodedFrameData { get; set; }
         public PaletteColor[] globalFrameData { get; set; }
 
         public FrameRGBACache? modifiedFrameRGBACache { get; set; }
@@ -244,15 +244,15 @@ namespace SPRNetTool.Data
                     frameRGBA.encryptedFrameData = value;
                 }
             }
-            public PaletteColor[] decodedFrameData
+            public PaletteColor[] modifiedFrameData
             {
                 get
                 {
-                    return frameRGBA.decodedFrameData;
+                    return frameRGBA.originDecodedFrameData;
                 }
                 set
                 {
-                    frameRGBA.decodedFrameData = value;
+                    frameRGBA.originDecodedFrameData = value;
                 }
             }
             public PaletteColor[] globalFrameData
@@ -270,6 +270,11 @@ namespace SPRNetTool.Data
             public FrameRGBA toFrameRGBA()
             {
                 return frameRGBA;
+            }
+
+            public void InitFrameRGBA(FrameRGBA initData)
+            {
+                frameRGBA = initData;
             }
         }
 

--- a/SPRNetTool/ViewModel/DebugPageViewModel.cs
+++ b/SPRNetTool/ViewModel/DebugPageViewModel.cs
@@ -422,7 +422,7 @@ namespace SPRNetTool.ViewModel
                             if (!castArgs.Event.HasFlag(SPR_FRAME_OFFSET_CHANGED) &&
                                 !castArgs.Event.HasFlag(SPR_FRAME_SIZE_CHANGED))
                             {
-                                SprFrameData = castArgs.SprFrameData ?? new FrameRGBA();
+                                SprFrameData = castArgs.SprFrameData?.modifiedFrameRGBACache?.toFrameRGBA() ?? new FrameRGBA();
                             }
                         }
                     }


### PR DESCRIPTION
### Cause: 
``` C#
SprFrameData = castArgs.SprFrameData ?? new FrameRGBA();
```
Vì khi set SprFrameData trong DebugPageViewModel bằng với frameOrigin gây lỗi sai logic 

-----------

### Measure:
đổi sang sử dụng frameData trong cache