### PR TITLE
[#134] Chức năng edit frame offset không hoạt động

### DIFF
--- a/SPRNetTool/Data/SPRData.cs
+++ b/SPRNetTool/Data/SPRData.cs
@@ -397,22 +397,16 @@ namespace SPRNetTool.Data
         public ushort OffY;
     }
 
-    public class FrameRGBA
+    public struct FrameRGBA
     {
-        public FrameRGBA() { }
-        public FrameRGBA(bool isInsertedFrame)
-        {
-            this.isInsertedFrame = isInsertedFrame;
-        }
-
         private FrameRGBACache? _modifiedFrameRGBACache;
         public ushort frameWidth { get; set; }
         public ushort frameHeight { get; set; }
         public short frameOffX { get; set; }
         public short frameOffY { get; set; }
-        public bool isInsertedFrame { get; private set; }
-        public PaletteColor[] originDecodedFrameData { get; set; } = new PaletteColor[0];
-        public PaletteColor[] globalFrameData { get; set; } = new PaletteColor[0];
+        public bool isInsertedFrame { get; set; }
+        public PaletteColor[] originDecodedFrameData { get; set; }
+        public PaletteColor[] globalFrameData { get; set; }
 
         public FrameRGBACache modifiedFrameRGBACache
         {
@@ -528,7 +522,6 @@ namespace SPRNetTool.Data
             {
                 return frameRGBA;
             }
-
 
             public void SetCopiedPaletteData(Palette paletteData)
             {

--- a/SPRNetTool/Domain/BitmapDisplayManager.cs
+++ b/SPRNetTool/Domain/BitmapDisplayManager.cs
@@ -524,17 +524,25 @@ namespace SPRNetTool.Domain
                         }
                     }
                 }
+
+                if (frameIndex > 0)
+                {
+                    DisplayedBitmapSourceCache.CurrentFrameIndex--;
+                    frameIndex--;
+                }
+                else if (frameIndex == 0)
+                {
+                    frameIndex = (uint)(SprWorkManager.FileHead.FrameCounts - 1);
+                    DisplayedBitmapSourceCache.CurrentFrameIndex = frameIndex;
+                }
+
                 DisplayedBitmapSourceCache.ColorSourceCaching?
                            .Apply(it => it[frameIndex] = it[frameIndex]
                            .IfNullThenLet(() => DisplayedBitmapSourceCache.DisplayedBitmapSource?
                            .Let(it => this.CountColorsToDictionary(it))));
                 DisplayedBitmapSourceCache.DisplayedColorSource = DisplayedBitmapSourceCache.ColorSourceCaching?[frameIndex];
                 DisplayedBitmapSourceCache.AnimationTokenSource = null;
-                if (frameIndex > 0)
-                {
-                    DisplayedBitmapSourceCache.CurrentFrameIndex--;
-                    frameIndex--;
-                }
+
                 NotifyChanged(new BitmapDisplayMangerChangedArg(
                         changedEvent: IS_PLAYING_ANIMATION_CHANGED
                             | CURRENT_DISPLAYING_SOURCE_CHANGED

--- a/SPRNetTool/Domain/SprWorkManager.cs
+++ b/SPRNetTool/Domain/SprWorkManager.cs
@@ -48,12 +48,13 @@ namespace SPRNetTool.Domain
             }
 #endif
 
-            var frameData = new FrameRGBA(isInsertedFrame: true)
+            var frameData = new FrameRGBA()
             {
                 frameHeight = frameHeight,
                 frameWidth = frameWidth,
                 frameOffX = 0,
-                frameOffY = 0
+                frameOffY = 0,
+                isInsertedFrame = true
             };
             frameData.originDecodedFrameData = pixelData;
             var newLen = (FrameData?.Length + 1) ?? 1;
@@ -152,8 +153,9 @@ namespace SPRNetTool.Domain
             if (frameIndex >= 0 && frameIndex < FileHead.FrameCounts && FrameData != null)
             {
                 var extendingColor = color ?? Colors.White;
-                if (newFrameWidth != FrameData[frameIndex].frameWidth
-                    || newFrameHeight != FrameData[frameIndex].frameHeight)
+                var modifiedFrameRGBACache = FrameData[frameIndex].modifiedFrameRGBACache;
+                if (newFrameWidth != modifiedFrameRGBACache.frameWidth
+                    || newFrameHeight != modifiedFrameRGBACache.frameHeight)
                 {
                     PaletteColor getPaletteColorInRef(uint newX, uint newY, ushort refFrameHeight, ushort refFrameWidth, PaletteColor[] refFrameData)
                     {
@@ -180,8 +182,6 @@ namespace SPRNetTool.Domain
                                     refFrameData: FrameData[frameIndex].originDecodedFrameData);
                         }
                     }
-
-                    var modifiedFrameRGBACache = FrameData[frameIndex].modifiedFrameRGBACache;
 
                     var oldWidth = modifiedFrameRGBACache.frameWidth;
                     var oldHeight = modifiedFrameRGBACache.frameHeight;


### PR DESCRIPTION
C: Khi dùng class thay vì struct của FrameRGBA, SprFrameData của tầng viewmodel sẽ refer đến data của domain
M: Sử dụng struct thay vì class