### PR TITLE
[#146] Sau khi save file spr, xuất hiện lỗi màu hiển thị frame khi insert new frame với file jpg

### DIFF
--- a/SPRNetTool/Data/SPRData.cs
+++ b/SPRNetTool/Data/SPRData.cs
@@ -341,6 +341,16 @@ namespace SPRNetTool.Data
             return false;
         }
 
+
+        public bool IsSame(Palette palette)
+        {
+            foreach (var item in palette.Data)
+            {
+                if(!IsContain(item)) return false;
+            }
+            return true;
+        }
+
         public static bool operator ==(Palette a, Palette b)
         {
             if (a.Size != b.Size) return false;

--- a/SPRNetTool/Domain/Utils/ColorUtil.cs
+++ b/SPRNetTool/Domain/Utils/ColorUtil.cs
@@ -1,4 +1,5 @@
-﻿using SPRNetTool.Domain.Base;
+﻿using SPRNetTool.Data;
+using SPRNetTool.Domain.Base;
 using System;
 using System.Windows.Media;
 
@@ -11,6 +12,14 @@ namespace SPRNetTool.Domain.Utils
             int deltaRed = thisColor.R - otherColor.R;
             int deltaGreen = thisColor.G - otherColor.G;
             int deltaBlue = thisColor.B - otherColor.B;
+            return Math.Sqrt(deltaRed * deltaRed + deltaGreen * deltaGreen + deltaBlue * deltaBlue);
+        }
+
+        public static double CalculateEuclideanDistance(this IDomainAdapter adapter, PaletteColor thisColor, PaletteColor otherColor)
+        {
+            int deltaRed = thisColor.Red - otherColor.Red;
+            int deltaGreen = thisColor.Green - otherColor.Green;
+            int deltaBlue = thisColor.Blue - otherColor.Blue;
             return Math.Sqrt(deltaRed * deltaRed + deltaGreen * deltaGreen + deltaBlue * deltaBlue);
         }
 


### PR DESCRIPTION
## Cause:
 Vì file jpg có số lượng màu nhiều hơn png, khi save file cần tạo 1 palette mới nhưng lại không apply palette này lên các frame hiên tại, dẫn tới việc lúc encrypt frame không tìm thấy được màu trên palette của từng pixel

## Measure:
Apply palette mới trên từng frame sau khi insert frame mới.