### PR TITLE
[#187] Sai vị trí hiển thị ảnh png

### DIFF
--- a/SPRNetTool/ViewModel/Widgets/BitmapViewerViewModel.cs
+++ b/SPRNetTool/ViewModel/Widgets/BitmapViewerViewModel.cs
@@ -207,6 +207,10 @@ namespace SPRNetTool.ViewModel.Widgets
                             FrameSource = castArgs.CurrentDisplayingSource;
                             if (!IsSpr)
                             {
+                                GlobalOffX = 0;
+                                GlobalOffY = 0;
+                                FrameOffX = 0;
+                                FrameOffY = 0;
                                 GlobalHeight = (uint)(castArgs.CurrentDisplayingSource?.PixelHeight ?? 0);
                                 GlobalWidth = (uint)(castArgs.CurrentDisplayingSource?.PixelWidth ?? 0);
                                 FrameHeight = (uint)(castArgs.CurrentDisplayingSource?.PixelHeight ?? 0);


### PR DESCRIPTION
C&M: Khi mở file png mà trước đó đã mở spr file, cần reset lại tọa độ global offset và frame offset