### PR TITLE
[#188] Thay đổi logic changed color caching cho frame do FC khi thay đổi màu trên palette editor

### DIFF
--- a/SPRNetTool/Data/SPRData.cs
+++ b/SPRNetTool/Data/SPRData.cs
@@ -640,7 +640,14 @@ namespace SPRNetTool.Data
 
             public void SetPaletteColorChangedIndex(int index, PaletteColor oldColor, PaletteColor newColor)
             {
-                paletteColorChangeIndexCache[index] = new(oldColor, newColor);
+                if (paletteColorChangeIndexCache.ContainsKey(index))
+                {
+                    paletteColorChangeIndexCache[index] = new(paletteColorChangeIndexCache[index].Item1, newColor);
+                }
+                else
+                {
+                    paletteColorChangeIndexCache[index] = new(oldColor, newColor);
+                }
                 IsPaletteColorChanged = true;
             }
             public int[] GetPaletteColorChangedIndex()

--- a/SPRNetTool/ViewModel/Widgets/BitmapViewerViewModel.cs
+++ b/SPRNetTool/ViewModel/Widgets/BitmapViewerViewModel.cs
@@ -207,6 +207,10 @@ namespace SPRNetTool.ViewModel.Widgets
                             FrameSource = castArgs.CurrentDisplayingSource;
                             if (!IsSpr)
                             {
+                                GlobalOffX = 0;
+                                GlobalOffY = 0;
+                                FrameOffX = 0;
+                                FrameOffY = 0;
                                 GlobalHeight = (uint)(castArgs.CurrentDisplayingSource?.PixelHeight ?? 0);
                                 GlobalWidth = (uint)(castArgs.CurrentDisplayingSource?.PixelWidth ?? 0);
                                 FrameHeight = (uint)(castArgs.CurrentDisplayingSource?.PixelHeight ?? 0);


### PR DESCRIPTION
Cause:
Khi thay đổi màu tại cùng 1 vị trí trong bảng palette, giá trị old color cache sẽ được ghi đè ngay cả khi màu old color đó chưa được apply vào mảng dữ liệu

Measure:
Khi thay đổi tại cùng 1 vị trí, cần kiểm tra xem tại ví trí đó cache có đang rỗng không, nếu không chứng tỏ màu đó chưa được apply vào mảng dữ liệu và cần phải dữ nguyên giá trị old color, chỉ thay đổi new color.