### PR TITLE
[#207] Lỗi kênh màu alpha khi save file spr từ nhiều frame được insert

### DIFF
--- a/SPRNetTool/Data/SPRData.cs
+++ b/SPRNetTool/Data/SPRData.cs
@@ -520,7 +520,7 @@ namespace SPRNetTool.Data
             private FrameRGBA frameRGBA;
             private Palette paletteData;
 
-            public Dictionary<Color, long>? CountableSource { get; set; }
+            public Dictionary<Color, long>? RgbCountableSource { get; set; }
             public Dictionary<int, List<long>>? PaletteIndexToPixelIndexMap { get; set; }
 
             public FrameRGBACache(FrameRGBA originData)

--- a/SPRNetTool/Data/SPRData.cs
+++ b/SPRNetTool/Data/SPRData.cs
@@ -407,7 +407,9 @@ namespace SPRNetTool.Data
         {
             foreach (var item in Data)
             {
-                if (item == color) return true;
+                if (color.Blue == item.Blue &&
+                    color.Green == item.Green &&
+                    color.Red == item.Red) return true;
             }
             return false;
         }

--- a/SPRNetTool/Domain/Base/ISprWorkManagerAdvance.cs
+++ b/SPRNetTool/Domain/Base/ISprWorkManagerAdvance.cs
@@ -34,7 +34,7 @@ namespace SPRNetTool.Domain.Base
             , PaletteColor[] pixelData
             , byte[] bgraBytesData
             , Palette paletteData
-            , Dictionary<Color, long>? argbCountableSource = null
+            , Dictionary<Color, long>? rgbCountableSource = null
             , Dictionary<int, List<long>>? paletteColorIndexToPixelIndexMap = null);
 
         /// <summary>

--- a/SPRNetTool/Domain/Base/ISprWorkManagerAdvance.cs
+++ b/SPRNetTool/Domain/Base/ISprWorkManagerAdvance.cs
@@ -34,7 +34,7 @@ namespace SPRNetTool.Domain.Base
             , PaletteColor[] pixelData
             , byte[] bgraBytesData
             , Palette paletteData
-            , Dictionary<Color, long>? countableSource = null
+            , Dictionary<Color, long>? argbCountableSource = null
             , Dictionary<int, List<long>>? paletteColorIndexToPixelIndexMap = null);
 
         /// <summary>

--- a/SPRNetTool/Domain/BitmapDisplayManager.cs
+++ b/SPRNetTool/Domain/BitmapDisplayManager.cs
@@ -433,8 +433,6 @@ namespace SPRNetTool.Domain
                         frameCount: (uint)(DisplayedBitmapSourceCache.AnimationSourceCaching?.Length ?? 0))));
                 return;
             }
-
-
         }
 
         #endregion
@@ -567,6 +565,7 @@ namespace SPRNetTool.Domain
 
             var palettePixelArray = this.ConvertBitmapSourceToPaletteColorArray(bitmapSource,
                 out Dictionary<Color, long> argbCountableSource,
+                out Dictionary<Color,long> rgbCountableSource,
                 out Palette palette,
                 out byte[] bgraBytesData,
                 out Dictionary<int, List<long>> paletteColorIndexToPixelIndexMap)
@@ -582,7 +581,7 @@ namespace SPRNetTool.Domain
                 , palettePixelArray
                 , bgraBytesData
                 , palette
-                , argbCountableSource
+                , rgbCountableSource
                 , paletteColorIndexToPixelIndexMap))
             {
                 // Update current displaying bitmap

--- a/SPRNetTool/Domain/BitmapDisplayManager.cs
+++ b/SPRNetTool/Domain/BitmapDisplayManager.cs
@@ -549,15 +549,24 @@ namespace SPRNetTool.Domain
 
         private bool InsertBimapSourceToSprWorkSpace(uint frameIndex, BitmapSource bitmapSource, string? filePath = null)
         {
-            var countSource = this.CountColorsToDictionary(bitmapSource);
-            if (countSource.Count > 256)
+            this.CountColors(
+                    bitmapSource
+                    , out long argbCount
+                    , out long rgbCount
+                    , out _
+                    , out HashSet<Color> rgbSrc);
+            if (argbCount > rgbCount && rgbCount <= 256)
+            {
+
+            }
+            else
             {
                 bitmapSource = (this as IBitmapDisplayManager).OptimzeImageColorNA256(bitmapSource)
-                    ?? throw new Exception($"Failed to optimize image colors.");
+                   ?? throw new Exception($"Failed to optimize image colors.");
             }
 
             var palettePixelArray = this.ConvertBitmapSourceToPaletteColorArray(bitmapSource,
-                out Dictionary<Color, long> countableSource,
+                out Dictionary<Color, long> argbCountableSource,
                 out Palette palette,
                 out byte[] bgraBytesData,
                 out Dictionary<int, List<long>> paletteColorIndexToPixelIndexMap)
@@ -573,7 +582,7 @@ namespace SPRNetTool.Domain
                 , palettePixelArray
                 , bgraBytesData
                 , palette
-                , countableSource
+                , argbCountableSource
                 , paletteColorIndexToPixelIndexMap))
             {
                 // Update current displaying bitmap

--- a/SPRNetTool/Domain/SprWorkManagerAdvance.cs
+++ b/SPRNetTool/Domain/SprWorkManagerAdvance.cs
@@ -75,7 +75,7 @@ namespace SPRNetTool.Domain
             PaletteColor[] pixelData,
             byte[] bgraBytesData,
             Palette paletteData,
-            Dictionary<Color, long>? argbCountableSource,
+            Dictionary<Color, long>? rgbCountableSource,
             Dictionary<int, List<long>>? paletteColorIndexToPixelIndexMap)
         {
 #if DEBUG
@@ -83,11 +83,7 @@ namespace SPRNetTool.Domain
                out long argbCount,
                out long rgbCount,
                out Dictionary<Color, long> argbColorSource,
-               out HashSet<Color> rgbSrc);
-            if (argbCountableSource != null && !this.AreCountableSourcesEqual(argbCountableSource, argbColorSource))
-            {
-                throw new Exception("failed to count color source!");
-            }
+               out Dictionary<Color, long> rgbColorSource);
             if (rgbCount > 256) throw new Exception("Number of color from pixel data must be smaller or equal 256.");
             foreach (var color in pixelData)
             {
@@ -142,10 +138,10 @@ namespace SPRNetTool.Domain
 
             FileHead.modifiedSprFileHeadCache.FrameCounts++;
             FrameData = newFramesData;
-            newFramesData[frameIndex].modifiedFrameRGBACache.CountableSource = argbCountableSource;
+            newFramesData[frameIndex].modifiedFrameRGBACache.RgbCountableSource = rgbCountableSource;
 #if DEBUG
-            if (argbCountableSource == null)
-                newFramesData[frameIndex].modifiedFrameRGBACache.CountableSource = argbColorSource;
+            if (rgbCountableSource == null)
+                newFramesData[frameIndex].modifiedFrameRGBACache.RgbCountableSource = rgbColorSource;
 #endif
             return true;
         }

--- a/SPRNetTool/Domain/SprWorkManagerAdvance.cs
+++ b/SPRNetTool/Domain/SprWorkManagerAdvance.cs
@@ -75,16 +75,20 @@ namespace SPRNetTool.Domain
             PaletteColor[] pixelData,
             byte[] bgraBytesData,
             Palette paletteData,
-            Dictionary<Color, long>? countableSource,
+            Dictionary<Color, long>? argbCountableSource,
             Dictionary<int, List<long>>? paletteColorIndexToPixelIndexMap)
         {
 #if DEBUG
-            var countableColorSource = this.CountColors(pixelData);
-            if (countableSource != null && !this.AreCountableSourcesEqual(countableSource, countableColorSource))
+            this.CountColors(pixelData,
+               out long argbCount,
+               out long rgbCount,
+               out Dictionary<Color, long> argbColorSource,
+               out HashSet<Color> rgbSrc);
+            if (argbCountableSource != null && !this.AreCountableSourcesEqual(argbCountableSource, argbColorSource))
             {
                 throw new Exception("failed to count color source!");
             }
-            if (countableColorSource.Count > 256) throw new Exception("Number of color from pixel data must be smaller or equal 256.");
+            if (rgbCount > 256) throw new Exception("Number of color from pixel data must be smaller or equal 256.");
             foreach (var color in pixelData)
             {
                 if (!paletteData.IsContain(color))
@@ -138,10 +142,10 @@ namespace SPRNetTool.Domain
 
             FileHead.modifiedSprFileHeadCache.FrameCounts++;
             FrameData = newFramesData;
-            newFramesData[frameIndex].modifiedFrameRGBACache.CountableSource = countableSource;
+            newFramesData[frameIndex].modifiedFrameRGBACache.CountableSource = argbCountableSource;
 #if DEBUG
-            if (countableSource == null)
-                newFramesData[frameIndex].modifiedFrameRGBACache.CountableSource = countableColorSource;
+            if (argbCountableSource == null)
+                newFramesData[frameIndex].modifiedFrameRGBACache.CountableSource = argbColorSource;
 #endif
             return true;
         }

--- a/SPRNetTool/Domain/SprWorkManagerCore.cs
+++ b/SPRNetTool/Domain/SprWorkManagerCore.cs
@@ -495,7 +495,11 @@ namespace SPRNetTool.Domain
             // kể cả frame ban đầu và frame được insert mới
             var countableSource = FrameData
                 .Select(it => it.modifiedFrameRGBACache.CountableSource
-                    ?? this.CountColors(it.modifiedFrameRGBACache.modifiedFrameData)
+                    ?? this.CountColors(it.modifiedFrameRGBACache.modifiedFrameData,
+                        out _,
+                        out _,
+                        out _,
+                        out _)
                         .Also(it2 => it.modifiedFrameRGBACache.CountableSource = it2))
                 .ToArray();
             var newPaletteSource = this.SelectMostUsePaletteColorFromCountableColorSource(

--- a/SPRNetTool/Domain/SprWorkManagerCore.cs
+++ b/SPRNetTool/Domain/SprWorkManagerCore.cs
@@ -55,19 +55,22 @@ namespace SPRNetTool.Domain
             var newPixelData = new PaletteColor[dataSize];
             for (int i = 0; i < dataSize; i++)
             {
-                newPixelData[i] = FindClosetColorInPalette(
+                // Must keep old alpha, because palette only apply for rgb color
+                var oldAlpha = it.modifiedFrameRGBACache.modifiedFrameData[i].Alpha;
+                newPixelData[i] = FindClosetRGBColorInPalette(
                     it.modifiedFrameRGBACache.modifiedFrameData[i], newPalettData);
+                newPixelData[i].Alpha = oldAlpha;
             }
             it.modifiedFrameRGBACache.modifiedFrameData = newPixelData;
         }
 
-        private PaletteColor FindClosetColorInPalette(PaletteColor targetColor, Palette palette)
+        private PaletteColor FindClosetRGBColorInPalette(PaletteColor targetColor, Palette palette)
         {
             var distance = double.MaxValue;
             var outColor = new PaletteColor();
             for (int i = 0; i < palette.Size; i++)
             {
-                var newDistance = this.CalculateEuclideanDistance(targetColor, palette.Data[i]);
+                var newDistance = this.CalculateRGBEuclideanDistance(targetColor, palette.Data[i]);
                 if (newDistance < distance)
                 {
                     distance = newDistance;
@@ -494,13 +497,13 @@ namespace SPRNetTool.Domain
             // Tính lại toàn bộ lượng màu sử dụng trên từng frame
             // kể cả frame ban đầu và frame được insert mới
             var countableSource = FrameData
-                .Select(it => it.modifiedFrameRGBACache.CountableSource
+                .Select(it => it.modifiedFrameRGBACache.RgbCountableSource
                     ?? this.CountColors(it.modifiedFrameRGBACache.modifiedFrameData,
                         out _,
                         out _,
                         out _,
                         out _)
-                        .Also(it2 => it.modifiedFrameRGBACache.CountableSource = it2))
+                        .Also(it2 => it.modifiedFrameRGBACache.RgbCountableSource = it2))
                 .ToArray();
             var newPaletteSource = this.SelectMostUsePaletteColorFromCountableColorSource(
                 colorDifferenceDelta: 100,

--- a/SPRNetTool/Domain/Utils/BitmapUtil.cs
+++ b/SPRNetTool/Domain/Utils/BitmapUtil.cs
@@ -383,10 +383,10 @@ namespace SPRNetTool.Domain.Utils
             out long argbCount,
             out long rgbCount,
             out Dictionary<Color, long> argbSrc,
-            out HashSet<Color> rgbSrc)
+            out Dictionary<Color, long> rgbSrc)
         {
             Dictionary<Color, long> aRGBColorSet = new Dictionary<Color, long>();
-            HashSet<Color> rGBColorSet = new HashSet<Color>();
+            Dictionary<Color, long> rGBColorSet = new Dictionary<Color, long>();
 
             for (int i = 0; i < pixelArray.Length; i++)
             {
@@ -404,8 +404,16 @@ namespace SPRNetTool.Domain.Utils
                 {
                     aRGBColorSet[colorARGB]++;
                 }
+
                 Color colorRGB = Color.FromRgb(red, green, blue);
-                rGBColorSet.Add(colorRGB);
+                if (!rGBColorSet.ContainsKey(colorRGB))
+                {
+                    rGBColorSet[colorRGB] = 1;
+                }
+                else
+                {
+                    rGBColorSet[colorRGB]++;
+                }
             }
             argbCount = aRGBColorSet.Count;
             rgbCount = rGBColorSet.Count;
@@ -512,6 +520,7 @@ namespace SPRNetTool.Domain.Utils
         public static PaletteColor[] ConvertBitmapSourceToPaletteColorArray(this IDomainAdapter adapter,
             BitmapSource bitmapSource,
             out Dictionary<Color, long> argbCountableSource,
+            out Dictionary<Color, long> rgbCountableSource,
             out Palette palette,
             out byte[] bgraBytesData,
             out Dictionary<int, List<long>> paletteColorIndexToPixelIndexMap)
@@ -536,7 +545,7 @@ namespace SPRNetTool.Domain.Utils
 
             PaletteColor[] paletteColors = new PaletteColor[width * height];
             argbCountableSource = new Dictionary<Color, long>();
-            var rgbSource = new HashSet<Color>();
+            var rgbSource = new Dictionary<Color, long>();
             for (int i = 0; i < width * height; i++)
             {
                 var argbColor = Colors.Transparent;
@@ -593,24 +602,26 @@ namespace SPRNetTool.Domain.Utils
                     argbCountableSource.Add(argbColor, 1);
                 }
 
-                if (rgbSource.Contains(rgbColor))
+                if (rgbSource.ContainsKey(rgbColor))
                 {
                     colorPixelIndexMap[rgbColor].Add(i);
+                    rgbSource[rgbColor]++;
                 }
                 else
                 {
                     colorPixelIndexMap.Add(rgbColor, new List<long> { i });
-                    rgbSource.Add(rgbColor);
+                    rgbSource.Add(rgbColor, 1);
                 }
             }
             palette = new Palette(rgbSource.Count);
             int j = 0;
-            foreach (var color in rgbSource)
+            foreach (var color in rgbSource.Keys)
             {
                 palette.Data[j] = new PaletteColor(color.B, color.G, color.R, 255);
                 paletteColorIndexToPixelIndexMap.Add(j, colorPixelIndexMap[color]);
                 j++;
             }
+            rgbCountableSource = rgbSource;
             return paletteColors;
         }
         #endregion

--- a/SPRNetTool/Domain/Utils/ColorUtil.cs
+++ b/SPRNetTool/Domain/Utils/ColorUtil.cs
@@ -15,7 +15,7 @@ namespace SPRNetTool.Domain.Utils
             return Math.Sqrt(deltaRed * deltaRed + deltaGreen * deltaGreen + deltaBlue * deltaBlue);
         }
 
-        public static double CalculateEuclideanDistance(this IDomainAdapter adapter, PaletteColor thisColor, PaletteColor otherColor)
+        public static double CalculateRGBEuclideanDistance(this IDomainAdapter adapter, PaletteColor thisColor, PaletteColor otherColor)
         {
             int deltaRed = thisColor.Red - otherColor.Red;
             int deltaGreen = thisColor.Green - otherColor.Green;

--- a/SPRNetToolTest/Utils/BitmapUtilTest.cs
+++ b/SPRNetToolTest/Utils/BitmapUtilTest.cs
@@ -38,7 +38,8 @@ namespace SPRNetToolTest.Utils
             var bmpSource = mockDomainAdapter.LoadBitmapFromFile(imagePath);
             Assert.NotNull(bmpSource);
             var palarray = mockDomainAdapter.ConvertBitmapSourceToPaletteColorArray(bmpSource,
-                out Dictionary<Color, long> countableSource,
+                out Dictionary<Color, long> argbCountableSource,
+                out Dictionary<Color, long> rgbcountableSource,
                 out Palette palette,
                 out byte[] bgraBytesData,
                 out _);
@@ -48,12 +49,12 @@ namespace SPRNetToolTest.Utils
             var greenColor = Color.FromArgb(255, 34, 177, 76);
             var blueColor = Color.FromArgb(255, 0, 162, 232);
 
-            Assert.That(palarray.Length == countableSource.Sum(it => it.Value));
+            Assert.That(palarray.Length == argbCountableSource.Sum(it => it.Value));
             Assert.That(palette.Size == 4);
-            Assert.That(countableSource[redColor], Is.EqualTo(21456));
-            Assert.That(countableSource[yellowColor], Is.EqualTo(23999));
-            Assert.That(countableSource[greenColor], Is.EqualTo(22499));
-            Assert.That(countableSource[blueColor], Is.EqualTo(22046));
+            Assert.That(argbCountableSource[redColor], Is.EqualTo(21456));
+            Assert.That(argbCountableSource[yellowColor], Is.EqualTo(23999));
+            Assert.That(argbCountableSource[greenColor], Is.EqualTo(22499));
+            Assert.That(argbCountableSource[blueColor], Is.EqualTo(22046));
 
             Assert.That(palette.Data[0] == new PaletteColor(36, 28, 237, 255));
             Assert.That(palette.Data[1] == new PaletteColor(0, 242, 255, 255));
@@ -61,7 +62,7 @@ namespace SPRNetToolTest.Utils
             Assert.That(palette.Data[3] == new PaletteColor(232, 162, 0, 255));
 
             palarray = mockDomainAdapter.ConvertBitmapSourceToPaletteColorArray(bmpSource);
-            Assert.That(palarray.Length == countableSource.Sum(it => it.Value));
+            Assert.That(palarray.Length == argbCountableSource.Sum(it => it.Value));
         }
 
         [Test]
@@ -373,8 +374,6 @@ namespace SPRNetToolTest.Utils
             var x = 10;
 
         }
-
-
 
 
         [Test]

--- a/SPRNetToolTest/Utils/BitmapUtilTest.cs
+++ b/SPRNetToolTest/Utils/BitmapUtilTest.cs
@@ -156,7 +156,7 @@ namespace SPRNetToolTest.Utils
                 new PaletteColor(1,1,1,2),
                 new PaletteColor(1,1,1,1),
             };
-            mockDomainAdapter.CountColors(data);
+            mockDomainAdapter.CountColors(data, out _, out _, out _, out _);
         }
 
         [Test]


### PR DESCRIPTION
C: Các frame hiện tại khi được insert lúc lưu ra file sẽ được tính lại  giá trị palette color và apply palette mới dưới dạng rgb và chưa xử lý kênh alpha

M: Xử lý kênh alpha trong case trên