### PR TITLE
[#211] Sau khi đổi chỗ 2 frame, bitmap viewer hiển thị không chính xác

### DIFF
--- a/SPRNetTool/Domain/BitmapDisplayManager.cs
+++ b/SPRNetTool/Domain/BitmapDisplayManager.cs
@@ -212,6 +212,13 @@ namespace SPRNetTool.Domain
             {
                 if (success)
                 {
+                    DisplayedBitmapSourceCache.AnimationSourceCaching?.Apply(it =>
+                    {
+                        var tempCache = it[frameIndex2];
+                        it[frameIndex2] = it[frameIndex1];
+                        it[frameIndex1] = tempCache;
+                    });
+
                     if (DisplayedBitmapSourceCache.CurrentFrameIndex == frameIndex1)
                     {
                         DisplayedBitmapSourceCache.CurrentFrameIndex = frameIndex2;


### PR DESCRIPTION
C&M: Sau khi switch frame trong spr workspace, cần update bitmap source trong bitmap display manager